### PR TITLE
Repair `EdgePoint` pruning in `libtopology`

### DIFF
--- a/cola/libtopology/topology_graph.cpp
+++ b/cola/libtopology/topology_graph.cpp
@@ -126,6 +126,12 @@ bool EdgePoint::createBendConstraint(vpsc::Dim scanDim) {
     if(isEnd()) {
         return false;
     }
+    // don't try to generate a BendConstraint if both incident segments
+    // are parallel to the scan dimension
+    if(inSegment->length(vpsc::conjugate(scanDim)) == 0 &&
+       outSegment->length(vpsc::conjugate(scanDim)) == 0) {
+        return false;
+    }
     bendConstraint = new BendConstraint(this, scanDim);
     return true;
 }


### PR DESCRIPTION
To construct a `BendConstraint` at an `EdgePoint` requires that at least one of the two incident segments have non-zero length in the conjugate dimension.

We add a check in `EdgePoint::createBendConstraint()` to skip the case where both of these lengths are zero.

Such a case can arise when pruning degenerate EdgePoints, four or more of which are aligned in the scanning dimension.

Duplicates https://github.com/mjwybrow/adaptagrams/pull/57